### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#gcardoso - Front end Developer
+# gcardoso - Front end Developer
 
 My name is Gonçalo Cardoso and I’m an enthusiastic Front-end developer with a big passion for the digital world and what we developers can do to make it bigger and stronger.
 
 Here you can review the code of my [online portfolio](http://www.gcardoso.pt)
 
-##Main Features
+## Main Features
 
 - MongoDB for the portfolio data
 - Node.js server side


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
